### PR TITLE
added link to wireframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+Link to Wireframe:
+https://miro.com/app/board/uXjVITSuqPM=/?moveToWidget=3458764620334085912&cot=14


### PR DESCRIPTION
Added a link to our completed wireframe. Just to design our project in detail before trying to implement any code, because It is very important to have a design to work on otherwise we might make mistakes. We followed instructions and worked together on miro to design the board and followed a simple design to display data. In the readme there should be a link to the miro page which you can open in browser and see the wireframe.